### PR TITLE
More elegant fail implementation

### DIFF
--- a/src/luassert/bustez/expect.lua
+++ b/src/luassert/bustez/expect.lua
@@ -7,12 +7,12 @@ local say = require("say")
 
 -- This is needed to be used for busted to
 -- properly recognize it as fail on reporter(and not as error).
-local fail
-local success, _ = pcall(function()
-	fail = require("busted.core")().fail
-end)
+
 -- Falls back to normal error in case busted is not used.
-if not success then
+local fail
+if package.loaded.busted then
+	fail = require("busted.core")().fail
+else
 	fail = error
 end
 

--- a/test.lua
+++ b/test.lua
@@ -118,6 +118,26 @@ do
 	expect.stub(funStub).to.be.called_with(2, 3, 5)
 end
 
+do -- error message is a string by default
+	local _, msg = pcall(function()
+		expect(true).to.be_false()
+	end)
+
+	expect(msg).to.be.a.string()
+end
+
+do -- and busted.fail is used when busted is loaded
+	package.loaded["luassert.bustez.expect"] = nil
+	require("busted")
+	local busted_expect = require("luassert.bustez.expect")
+
+	local _, msg = pcall(function()
+		busted_expect(true).to.be_false()
+	end)
+
+	expect(msg).to.be.a.table()
+end
+
 do
 	---@class bustez.Expectation
 	---asserts that our expectation is not `nil`


### PR DESCRIPTION
- Fixes #2 again.
The fix always assumes that the user will use busted when it is installed. Calling an `expect` with busted installed(but not using it in the lua file) will result in the following error:
```
lua\bin\lua.EXE: (error object is not a string)
```
This is because `busted.fail` passes a table when it errors. This implementation is designed such that it will only load `busted.fail` only when it sees that busted is loaded.